### PR TITLE
build: re-enable renovate, and rename the config file to `default.json`

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,9 @@
 {
   "labels": ["maintenance"],
   "extends": ["config:base", ":disableDependencyDashboard"],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "rangeStrategy": "replace",
   "semanticCommitType": "build",
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -1,7 +1,6 @@
 {
   "labels": ["maintenance"],
   "extends": ["config:base", ":disableDependencyDashboard"],
-  "enabled": false,
   "rangeStrategy": "replace",
   "semanticCommitType": "build",
   "packageRules": [


### PR DESCRIPTION
Fixes #5