### PR TITLE
feat(default.json): use 'chore' as default semantic commit type

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,12 @@
   "semanticCommitType": "build",
   "packageRules": [
     {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "semanticCommitType": "chore"
+    },
+    {
       "depTypeList": ["dependencies"],
       "semanticCommitType": "fix"
     },


### PR DESCRIPTION
Fix #3 