### PR TITLE
ci: configure renovate to pin github actions digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,12 @@
 {
-  "labels": ["maintenance"],
-  "extends": ["config:base", ":disableDependencyDashboard"],
+  "labels": [
+    "maintenance"
+  ],
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard",
+    "helpers:pinGitHubActionDigests"
+  ],
   "lockFileMaintenance": {
     "enabled": false
   },
@@ -14,11 +20,15 @@
       "semanticCommitType": "chore"
     },
     {
-      "depTypeList": ["dependencies"],
+      "depTypeList": [
+        "dependencies"
+      ],
       "semanticCommitType": "fix"
     },
     {
-      "depTypeList": ["action"],
+      "depTypeList": [
+        "action"
+      ],
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"
     }


### PR DESCRIPTION
This adds the `helpers:pinGitHubActionDigests` configuration[^1]. It will pin GitHub actions tags to digests. For example `actions/checkout@v3.0.2` would become `actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2`

This is recommended by GitHub's security hardening for GitHub actions guide[^2]:

> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

[^1]: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
[^2]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions