### PR TITLE
chore: ignore `@pika/pack` upgrades due to known vulnerabilities

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,5 +25,6 @@
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"
     }
-  ]
+  ],
+  "ignoreDeps": ["@pika/pack"]
 }


### PR DESCRIPTION
ref: https://github.com/octokit/octokit.js/pull/2252