### PR TITLE
feat(workflows): create 'test.yml' reusable workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      node_versions:
+        required: true
+        type: string
+
+jobs:
+  test_matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 14
+          - 16
+          - 18
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - name: "Test with Node.js ${{ matrix.node_version }}"
+        uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a # tag=v3
+        with:
+          node-version: "${{ matrix.node_version }}"
+          cache: npm
+      - run: npm ci
+      - run: npm run test --ignore-scripts # run lint only once
+  test:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - run: npm ci
+      - run: npm run lint --if-present

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version:
-          - 14
-          - 16
-          - 18
+        node_version: ${{ fromJson(inputs.node_versions) }}
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
       - name: "Test with Node.js ${{ matrix.node_version }}"


### PR DESCRIPTION
Resolves #49

----

## Behavior
### Before the change?
* Each of Octokit's repositories has their own copy of `test.yml` for the CI tests.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* We create a common workflow for CI tests all Octokit's repositories will be able to re-use.

### Other information
<!-- Any other information that is important to this PR  -->
https://github.com/octokit/.github/issues/49

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type
`Type: Feature`

----