### PR TITLE
ci(renovate): configure renovate to unpin GitHub Actions digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,8 +2,7 @@
   "labels": ["maintenance"],
   "extends": [
     "config:base",
-    ":disableDependencyDashboard",
-    "helpers:pinGitHubActionDigests"
+    ":disableDependencyDashboard"
   ],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
# Description
Restore Renovate Bot configuration to unpin GitHub Actions digests.

# Context
Reduce Renovate Bot noise across Octokit.js organization generated by opening PRs for each repository using GitHub Workflows with third-party dependencies.

- Reverts https://github.com/octokit/.github/pull/9
- I propose to disable this security practice until we solve the development here: https://github.com/octokit/.github/pull/13