### PR TITLE
fix(renovate): remove `helpers:pinGitHubActionDigests`

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,8 +2,7 @@
   "labels": ["maintenance"],
   "extends": [
     "config:base",
-    ":disableDependencyDashboard",
-    "helpers:pinGitHubActionDigests"
+    ":disableDependencyDashboard"
   ],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
after discussing with @timrogers and @nickfloyd, we decided to remove pinning of actions until we set up https://github.com/octokit/.github/pull/13. The idea of `helpers:pinGitHubActionDigests` is a good one, but in our particular case, the costs of the noise it creates outweighs the benefits