### PR TITLE
fix(renovate): ignore `@octokit/types`

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,5 +25,5 @@
       "semanticCommitScope": "action"
     }
   ],
-  "ignoreDeps": ["@pika/pack"]
+  "ignoreDeps": ["@pika/pack", "@octokit/types"]
 }


### PR DESCRIPTION
This package should not be handled by renovate, it should be handled by @octokitbot