### PR TITLE
Updates default.json to add an explicit npm version constraint

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,9 @@
     "enabled": true,
     "schedule": ["before 5am on monday"]
   },
+  "constraints": {
+    "npm": "<9"
+  },
   "rangeStrategy": "replace",
   "semanticCommitType": "build",
   "packageRules": [


### PR DESCRIPTION
RE: https://github.com/renovatebot/renovate/discussions/19041

Even though [this](https://github.com/renovatebot/renovate/pull/19046) has been merged in to help prevent the issues that we were seeing with the lock files in our TypeScript/JavaScript repos, we should explicitly enforce it until we are ready to EOL support for Node 14 (April 2023).