### PR TITLE
Use linted version of add_to_octokit_project.yml

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -5,7 +5,7 @@ on:
     types: [reopened, opened]
   pull_request:
     types: [reopened, opened]
-    
+
 jobs:
   add-to-project:
     name: Add issue to project
@@ -15,5 +15,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/octokit/projects/10
           github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
-          labeled: 'Status: Stale'
+          labeled: "Status: Stale"
           label-operator: NOT


### PR DESCRIPTION
@nickfloyd brought it to my attention that we should fix the issue solved by [requestion-action#210](https://github.com/octokit/request-action/pull/210) by doing it here, which will fan out across all our repos.