### PR TITLE
Revert "Use linted version of add_to_octokit_project.yml"

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -5,7 +5,7 @@ on:
     types: [reopened, opened]
   pull_request:
     types: [reopened, opened]
-
+    
 jobs:
   add-to-project:
     name: Add issue to project
@@ -15,5 +15,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/octokit/projects/10
           github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
-          labeled: "Status: Stale"
+          labeled: 'Status: Stale'
           label-operator: NOT


### PR DESCRIPTION
Reverts octokit/.github#24. We still want these changes, but in order to test #25, this should be reverted so that we can replay them and take advantage of the automatic fanout. 