### PR TITLE
Updates add to project action to allow for failures on duplicate add to project attempts

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -12,6 +12,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:


### PR DESCRIPTION
Since the action step [add-to-project](https://github.com/marketplace/actions/add-to-github-projects) currently has no facilities internally to handle errors where the action attempts to add to project twice - open close open scenario as well as deal with the legacy `pull_request` trigger and the `pull_request_target` trigger overlap.

See this example [PR](https://github.com/octokit/octokit.net/pull/2642) for more info.