### PR TITLE
fix: remove `pull_request` as a trigger event, as forks and dependabot PRs don't have access to repository secrets

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -3,8 +3,6 @@ name: Add PRs and issues to Octokit org project
 on:
   issues:
     types: [reopened, opened]
-  pull_request:
-    types: [reopened, opened]
   pull_request_target:
     types: [reopened, opened]
 


### PR DESCRIPTION
Fixes https://github.com/octokit/plugin-paginate-rest.js/issues/489