### PR TITLE
Change default branch workflow reference

### DIFF
--- a/.github/workflows/publish-project-workflow.yml
+++ b/.github/workflows/publish-project-workflow.yml
@@ -2,7 +2,7 @@ name: Workflow Publisher
 on:
  workflow_dispatch:
  push:
-   branches: [ 'master']
+   branches: [ 'main']
    paths:
    - '.github/templates/**'
 jobs:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-         target_repo: ${{fromJson(needs.set-matrix.outputs.matrix)}} 
+         target_repo: ${{fromJson(needs.set-matrix.outputs.matrix)}}
     steps:
      - name: Checkout Workflows
        uses: actions/checkout@v3
@@ -51,4 +51,4 @@ jobs:
          labels: "Type: Maintenance"
          author: "Octokit Bot <33075676+octokitbot@users.noreply.github.com>"
          path: ${{ matrix.target_repo }}
-   
+


### PR DESCRIPTION
Now that the default branch is main, we should switch the Actions workflow to trigger off of the main branch rather than the (non-existent) master branch. 