### PR TITLE
feat(renovate-config): automerge lockFileMaintenance changes

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,10 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 5am on monday"]
+    "schedule": ["before 5am on monday"],
+    "automerge": true,
+    "automergeType": "branch",
+    "autoMergeStrategy": "squash"
   },
   "rangeStrategy": "replace",
   "semanticCommitType": "build",


### PR DESCRIPTION
# Description
- use 'squash' as a merge strategy (https://docs.renovatebot.com/configuration-options/#automergetype)
- merge the branch directly, do not open a PR to avoid noise to
  maintainers (https://docs.renovatebot.com/configuration-options/#automergetype)

# Context
Reduce noise and maintainers' time reviewing Renovate PRs
