### PR TITLE
Renovate: stop ignoring pika deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,6 +27,5 @@
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"
     }
-  ],
-  "ignoreDeps": ["@pika/pack"]
+  ]
 }


### PR DESCRIPTION
Now that pika [isn't a dependency](https://github.com/search?type=code&q=org%3Aoctokit+%22pika%22) of octokit repositories anymore, it's safe to remove this ignoring from our upstream renovate config. 