### PR TITLE
Update prioritization_response.md

### DIFF
--- a/community/prioritization_response.md
+++ b/community/prioritization_response.md
@@ -1,18 +1,18 @@
 ## Overview
 
-Given that we are a small functional team that is meant to maintain :wrench:, support ::phone::, care for :heart:, and cultivate :sunflower: our amazing Octokit :octocat: and Terraform community we often have to make decisions that are best for the entire community.
+Given that we are a small functional team that is meant to maintain :wrench:, support :phone:, care for :heart:, and cultivate :sunflower: our amazing Octokit :octocat: and Terraform community we often have to make decisions that are best for the entire community.
 We don't take this act of prioritization lightly nor are we haphazard about it. We want to honor the time and thought that everyone has put into all of the SDKs that we have come to know and :heart:.
 
-Add that to the number of repos that we need to maintain (70+) and weekly interactions (500-1000 +/-) that we end up having with everyone I am sure it's clear why we have to define how we **prioritize** and our commitment to respond (think of an **SLA** of sorts) to those priorities.
+With the number of repos that we need to maintain (70+) and weekly interactions (500-1000 +/-) that we end up having with everyone, we have to define how we **prioritize** and our commitment to respond (think of an **SLA** of sorts) to those priorities.
 
 ### What are the Priorities?
 
-In each of the repositories we own you'll see the same [labels](https://github.com/octokit/octokit.net/labels) for priority.  
+In each of the repositories we own you'll see the same [labels](https://github.com/octokit/octokit.net/labels) for priority.
 
-**They are:**  
+**They are:**
 `Priority: Critical`, `Priority: High`, `Priority: Normal`, `Priority: Low`
 
-Incidentally, these map directly to the priorities set in our [Octokit Active community board](https://github.com/orgs/octokit/projects/10/views/4).
+These map directly to the priorities set in our [Octokit Active community board](https://github.com/orgs/octokit/projects/10/views/4).
 
 | [Repo label](https://github.com/octokit/octokit.net/labels)   |      [Community board](https://github.com/orgs/octokit/projects/10/views/4) | Example |
 |----------|:-------------:|:-----------|
@@ -25,32 +25,32 @@ Incidentally, these map directly to the priorities set in our [Octokit Active co
 
 Note: This does not represent a commitment to resolution, just how quickly we'll respond and begin working on it
 
-| Priority  | Response expectation | 
+| Priority  | Response expectation |
 |----------|:-----------|
 | Urgent | 0 to **24hrs**:  A security advisory will be posted if needed and updates publically posted to the corresponding repository |
-| High | =< **1 Week** : Typically, we'll respond in issue/pr and will have a plan of action within the response expectation time window. | 
+| High | <= **1 Week** : Typically, we'll respond in issue/PR and will have a plan of action within the response expectation time window. |
 | Normal | >= **1 Week** : We'll acknowledge and make administrative assignments to the issue or PR.  They might get labeled "up-for-grabs". |
 | Low | > **1 Week**: Typically, little to no action will take place on these items. They will often get labeled "up-for-grabs". |
 
 
 ### How do we Prioritize?
 
-Remembering that we as a team have to prioritize not at the individual SDK or community level but across many repositories and communities our, methods need to consider several variables.
+Remembering that we as a team have to prioritize not at the individual SDK or community level but across many repositories and communities, our methods need to consider several variables.
 Our process, while not exactly scientific, is aimed at protecting the interests of our communities first - we use a modified version of [RICE](https://www.productplan.com/glossary/rice-scoring-model/).
 
 Here are some data points, empathetic aspects, and questions we use to help us prioritize.
 
 * Does the issue compromise data integrity, user security, or the integrity of GitHub?
-* How serious is the need? 
+* How serious is the need?
 * What's the overall impact on the SDK community?
-* What's the overall impact on the package communities
-* What's the overall impact on the language communities	
+* What's the overall impact on the package communities?
+* What's the overall impact on the language communities?
 * How active is the SDK community?
 * How many open issues are there?
 * How many open PRs are there?
 * What is the throughput of the given SDK where the issue is?
 * What is the overall usage footprint?
-* What’s the difficulty of the change set/fix?
+* What’s the difficulty of the changeset/fix?
 * How much friction is the issue causing?
 * What's the overall time/effort cost of addressing the issue/need?
 etc...

--- a/community/prioritization_response.md
+++ b/community/prioritization_response.md
@@ -23,17 +23,17 @@ These map directly to the priorities set in our [Octokit Active community board]
 
 ### What are our response commitments?
 
-Note: This does not represent a commitment to resolution, just how quickly we'll respond and begin working on it
+Note: This does not represent a commitment to resolution, just how quickly we'll acknowledge and respond.
 
 | Priority  | Response expectation |
 |----------|:-----------|
-| Urgent | 0 to **24hrs**:  A security advisory will be posted if needed and updates publically posted to the corresponding repository |
-| High | <= **1 Week** : Typically, we'll respond in issue/PR and will have a plan of action within the response expectation time window. |
-| Normal | >= **1 Week** : We'll acknowledge and make administrative assignments to the issue or PR.  They might get labeled "up-for-grabs". |
-| Low | > **1 Week**: Typically, little to no action will take place on these items. They will often get labeled "up-for-grabs". |
+| Urgent | 0 to **24hrs**:  A security advisory will be posted if needed and updates publically posted to the corresponding repository in issue or discussion form. |
+| High | <= **1 Week** : We'll respond in issue/PR and will have a plan of action within the response expectation time window. |
+| Normal | >= **1 Week** : We'll acknowledge and make administrative assignments to the issue or PR. It may be labeled "up-for-grabs", where we encourage community contribution. |
+| Low | > **1 Week**: Typically, little to no action will take place on these items. |
 
 
-### How do we Prioritize?
+### How do we prioritize?
 
 Remembering that we as a team have to prioritize not at the individual SDK or community level but across many repositories and communities, our methods need to consider several variables.
 Our process, while not exactly scientific, is aimed at protecting the interests of our communities first - we use a modified version of [RICE](https://www.productplan.com/glossary/rice-scoring-model/).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,9 +1,9 @@
 ![image](https://user-images.githubusercontent.com/139819/199528006-bc534966-4aee-45da-8d1e-0e71b97a56b3.png)
 
 
-👋 Hey Octokit friends! 
+👋 Hey Octokit friends!
 
-We're glad you're here! This is where we host all of our Official[^1] SDKs for the GitHub API. 
+We're glad you're here! This is where we host all of our Official[^1] SDKs for the GitHub API.
 
 Currently, GitHub maintains SDKs for the following languages/frameworks/platforms:
 - [JavaScript](https://github.com/octokit?language=javascript#org-profile-repositories) / [TypeScript](https://github.com/octokit?language=typescript#org-profile-repositories)
@@ -16,16 +16,17 @@ If you're already a contributor we can't thank you enough for being part of maki
 
 ## Code of conduct
 
-Open source projects can be amazing things and while the source code they provide is an important component of the project 
-it's definitely not the only thing that makes it amazing... you are! 
+Open source projects can be amazing things and while the source code they provide is an important component of the project
+it's definitely not the only thing that makes it amazing... you are!
 
 Practice kindnes, be welcoming, and always assume that we all have something to learn. Take a minute to read more about our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Contributing
 
-While each community in our collection of Octokit communities is unique and have some really great nuances we have standard approaches across all of our repos
-to lower barriors to entry and reduce the friction of getting things done. Make sure to have a look at each of the repositorie's `CONTRIBUTING` docs above when 
-making contributions. Oh, and thanks for being amazing and helping to both improve our communities and code! ❤️
+While each community in our collection of Octokit communities is unique and has its own individuality, we have standard approaches across all of our repos
+to lower barriors to entry and reduce the friction of getting things done. Make sure to have a look at each repository's `CONTRIBUTING` docs above when
+making contributions. For more information on how our team prioritizes and responds to issues, PRs, and discussions, please see [this document](../community/prioritization_response.md).
+Oh, and thanks for being amazing and helping to both improve our communities and code! ❤️
 
-[^1]:Official just means GitHub and folks from GitHub support and maintain these libraries on an ongoing basis. 
+[^1]:Official just means GitHub and folks from GitHub support and maintain these libraries on an ongoing basis.
 You can checkout some of the other amazing SDKs created and maintained by the community [here](https://docs.github.com/en/rest/overview/libraries)!


### PR DESCRIPTION
Work in progress. 

This PR is a review of our prioritization_response.md document ~6 months after its initial creation. Also, the [landing page](https://github.com/octokit) README doc points toward prioritization_response.md now. 

:eyes: [Rendered version](https://github.com/octokit/.github/blob/external-comms/community/prioritization_response.md) :eyes: 