### PR TITLE
Create immediate-response.yml template to be propagated to all octokit

### DIFF
--- a/.github/templates/immediate-response.yml
+++ b/.github/templates/immediate-response.yml
@@ -1,0 +1,29 @@
+name: Issue/PR response
+permissions:
+  issues: write
+  pull-requests: write
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+jobs:
+  respond-to-issue:
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine issue or PR number
+        id: extract
+        run: echo "NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Respond to issue or PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ steps.extract.outputs.NUMBER }}
+          body: >
+            👋 Hi! Thank you for this contribution! Just to let you know, our GitHub SDK team does a round of issue and PR reviews twice a week, every Monday and Friday!
+            We have a [process in place](https://github.com/octokit/.github/blob/main/community/prioritization_response.md#overview) for prioritizing and responding to your input. 
+            Because you are a part of this community please feel free to comment, add to, or pick up any issues/PRs that are labled with `Status: Up for grabs`.
+            You & others like you are the reason all of this works! So thank you & happy coding! 🚀


### PR DESCRIPTION
Fixes: https://github.com/octokit/octokit.js/issues/2534

This will:
1. Create a template workflow that explicitly sets the version of the package
2. Propagate the workflow across all of octokit and update all of the existing ones

Future considerations:
Possibly replace with reusable workflows as @gr2m suggested [here](https://github.com/octokit/octokit.js/issues/2534#issuecomment-1719887768).
