### PR TITLE
Change "pull_request" event to "pull_request_target"

### DIFF
--- a/.github/templates/immediate-response.yml
+++ b/.github/templates/immediate-response.yml
@@ -6,7 +6,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:


### PR DESCRIPTION
`pull_request_target` event is more appropriate for the `Issue/PR response` workflow, as the workflow executes against pull requests but in the context of base repository (for security reasons).

Otherwise, when a PR is triggered by the `pull_request` event the `GITHUB_TOKEN` authorization scope may not allow executing API calls in the context of workflows from a pull request based on repository forks.

Resolves https://github.com/octokit/plugin-paginate-graphql.js/issues/139

[respond-to-issue](https://github.com/octokit/plugin-paginate-graphql.js/actions/runs/7148140055/job/19468767085?pr=137#logs) fails e.g. ≫ https://github.com/octokit/plugin-paginate-graphql.js/actions/runs/7148140055/job/19468767085?pr=137