### PR TITLE
Handle running in forks

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [reopened, opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   add-to-project:
     name: Add issue to project
@@ -14,7 +18,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:
-          project-url: https://github.com/orgs/octokit/projects/10
-          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          project-url: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN && 'https://github.com/orgs/octokit/projects/10' || '' }}
+          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN || github.token }}
           labeled: "Status: Stale"
           label-operator: NOT


### PR DESCRIPTION
In a fork, the secret is unlikely to be present.

By making the project-url conditional on the secret, it'll basically never be set in forks (unless you work on octokit and happen to choose to create a secret to use for the purpose of testing -- which is unlikely).

Setting github-token to `github.token` as a fallback means that the workflow will run in forks w/o triggering :x: which is slightly better. Eventually users will still disable it because it's annoying, but only once they manage to create a PR or issue in their fork and it runs and tags it...

per https://github.com/octokit/request.js/pull/669#issuecomment-1935478589