### PR TITLE
build(renovate): dedupe lockfile after update

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,5 +27,6 @@
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"
     }
-  ]
+  ],
+  "postUpdateOptions": ["npmDedupe"]
 }


### PR DESCRIPTION
I'm noticing that in many repositories, renovate does not dedupe dependencies, or doesn't update dependencies that are in range. Hopefully this will help with that