### PR TITLE
Publish project workflow fixes

### DIFF
--- a/.github/workflows/publish-project-workflow.yml
+++ b/.github/workflows/publish-project-workflow.yml
@@ -1,54 +1,60 @@
 name: Workflow Publisher
 on:
- workflow_dispatch:
- push:
-   branches: [ 'main']
-   paths:
-   - '.github/templates/**'
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/templates/**"
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-     - uses: actions/checkout@v3
-     - id: set-matrix
-       run: |
-         JSON=$(cat .github/workflows/repos.json)
-         echo "matrix=${JSON//'%'/'%25'}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - id:
+          set-matrix
+          # parse the repos.json file, replace '%' with '%25', remove newlines and tabs,
+          # and set the output as a matrix to be operated upon
+        run: |
+          JSON=$(cat .github/workflows/repos.json)
+          matrix=$(echo "${JSON//'%'/'%25'}" | tr -d '\n\t')
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
   publish-workflow-template:
     needs: set-matrix
     runs-on: ubuntu-latest
+    # since we're running a matrix job across multiple repos, we don't want all processing
+    # to stop if one repo fails, is archived, etc.
+    continue-on-error: true
     strategy:
       max-parallel: 2
       matrix:
-         target_repo: ${{fromJson(needs.set-matrix.outputs.matrix)}}
+        target_repo: ${{fromJson(needs.set-matrix.outputs.matrix)}}
     steps:
-     - name: Checkout Workflows
-       uses: actions/checkout@v3
-       with:
-         path: main
-     - name: Checkout target repo
-       uses: actions/checkout@v3
-       with:
-         repository: ${{ matrix.target_repo }}
-         path: ${{ matrix.target_repo }}
-         token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN}}
-     - name: Update workflows
-       working-directory: ./
-       shell: bash
-       run: |
-         mkdir -p ${{ matrix.target_repo }}/.github/workflows/
-         cp main/.github/templates/* ${{ matrix.target_repo }}/.github/workflows/
-     - name: Create Pull Request
-       uses: peter-evans/create-pull-request@v4
-       with:
-         token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
-         commit-message: "Updates for workflows"
-         title: "🚧 Workflows have changed"
-         body: "Workflow changes have been made in the Octokit org repo.  This PR is propagating those changes."
-         branch: workflow-update
-         labels: "Type: Maintenance"
-         author: "Octokit Bot <33075676+octokitbot@users.noreply.github.com>"
-         path: ${{ matrix.target_repo }}
-
+      - name: Checkout Workflows
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Checkout target repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.target_repo }}
+          path: ${{ matrix.target_repo }}
+          token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN}}
+      - name: Update workflows
+        working-directory: ./
+        shell: bash
+        run: |
+          mkdir -p ${{ matrix.target_repo }}/.github/workflows/
+          cp main/.github/templates/* ${{ matrix.target_repo }}/.github/workflows/
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          commit-message: "Updates for workflows"
+          title: "🚧 Workflows have changed"
+          body: "Workflow changes have been made in the Octokit org repo.  This PR is propagating those changes."
+          branch: workflow-update
+          labels: "Type: Maintenance"
+          author: "Octokit Bot <33075676+octokitbot@users.noreply.github.com>"
+          path: ${{ matrix.target_repo }}

--- a/.github/workflows/repos.json
+++ b/.github/workflows/repos.json
@@ -27,7 +27,6 @@
 	"octokit/oauth-methods.js",
 	"octokit/octokit-metrics",
 	"octokit/octokit-next.js",
-	"octokit/octokit.github.com",
 	"octokit/octokit.graphql.net",
 	"octokit/octokit.js",
 	"octokit/octokit.net",


### PR DESCRIPTION
Back for another round of fixes inspired by @nickfloyd's comments on https://github.com/octokit/.github/pull/85! 

- I've noticed in https://github.com/octokit/.github/actions/runs/9358090587/job/25759237429 that workflows are failing on archived repositories. To fix that,
    - I've added `continue-on-error: true` so that other matrix jobs will still process when one fails (so hopefully we'll end up in less half-complete states like we have now)
    - I've removed the one known archived repo `octokit/octokit.github.com` from the repos.json file
- I've also tested the logic that sets the matrix values and modified it to remove tabs and newlines so the output is similar to the old output when the matrix values are set in GitHub Actions. 

Old $matrix output (note the inconsistent spacing): 
````matrix=["integrations/terraform-provider-github", "octokit/dotnet-sdk", "octokit/go-sdk", "octokit/octokit.net","octokit/octokit.graphql.net","octokit/octokit-metrics","octokit/webhooks.net","octokit/octokit.rb","octokit/octopoller.rb","octokit/octokit.js","octokit/graphql-schema","octokit/webhooks.js","octokit/discussions","octokit/octokit.github.com","octokit/fixtures","octokit/plugin-paginate-graphql.js","octokit/plugin-retry.js","octokit/auth-unauthenticated.js","octokit/plugin-request-log.js","octokit/auth-app.js","octokit/types.ts","octokit/plugin-paginate-rest.js","octokit/webhooks-methods.js","octokit/auth-oauth-user.js","octokit/auth-oauth-device.js","octokit/app.js","octokit/oauth-methods.js","octokit/plugin-rest-endpoint-methods.js","octokit/auth-callback.js","octokit/oauth-authorization-url.js","octokit/plugin-enterprise-cloud.js","octokit/plugin-create-or-update-text-file.js","octokit/request-error.js","octokit/oauth-app.js","octokit/action.js","octokit/auth-action.js","octokit/auth-oauth-app.js","octokit/plugin-enterprise-server.js","octokit/endpoint.js","octokit/webhooks","octokit/plugin-enterprise-compatibility.js","octokit/auth-token.js","octokit/request.js","octokit/graphql.js","octokit/core.js","octokit/fixtures-server","octokit/app-permissions","octokit/request-action","octokit/rest.js","octokit/create-octokit-project.js","octokit/graphql-action","octokit/octokit-next.js","octokit/openapi-types.ts","octokit/openapi","octokit/sandbox"]```

New matrix output (same values except for consistently no whitespace): 
```
matrix=["integrations/terraform-provider-github","octokit/action.js","octokit/app-permissions","octokit/app.js","octokit/auth-action.js","octokit/auth-app.js","octokit/auth-callback.js","octokit/auth-oauth-app.js","octokit/auth-oauth-device.js","octokit/auth-oauth-user.js","octokit/auth-token.js","octokit/auth-unauthenticated.js","octokit/core.js","octokit/create-octokit-project.js","octokit/discussions","octokit/dotnet-sdk","octokit/endpoint.js","octokit/fixtures","octokit/fixtures-server","octokit/go-sdk","octokit/graphql-action","octokit/graphql-schema","octokit/graphql.js","octokit/oauth-app.js","octokit/oauth-authorization-url.js","octokit/oauth-methods.js","octokit/octokit-metrics","octokit/octokit-next.js","octokit/octokit.graphql.net","octokit/octokit.js","octokit/octokit.net","octokit/octokit.rb","octokit/octopoller.rb","octokit/openapi","octokit/openapi-types.ts","octokit/plugin-create-or-update-text-file.js","octokit/plugin-enterprise-cloud.js","octokit/plugin-enterprise-compatibility.js","octokit/plugin-enterprise-server.js","octokit/plugin-paginate-graphql.js","octokit/plugin-paginate-rest.js","octokit/plugin-request-log.js","octokit/plugin-rest-endpoint-methods.js","octokit/plugin-retry.js","octokit/request-action","octokit/request-error.js","octokit/request.js","octokit/rest.js","octokit/sandbox","octokit/source-generator","octokit/types.ts","octokit/webhooks","octokit/webhooks-methods.js","octokit/webhooks.js","octokit/webhooks.net"]
```