### PR TITLE
renovate: group express packages, don't create `fix` PRs that only update the lockFile

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,12 +21,21 @@
     {
       "depTypeList": ["dependencies", "peerDependencies"],
       "semanticCommitType": "fix"
+      "matchJsonata": "$exists(isLockfileUpdate) = false"
     },
     {
       "depTypeList": ["action"],
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"
+    },
+    {
+      "groupName": "express",
+      "matchPackageNames": [
+        "@types/express",
+        "express",
+      ]
     }
+  ]
   ],
   "postUpdateOptions": ["npmDedupe"]
 }

--- a/default.json
+++ b/default.json
@@ -35,7 +35,6 @@
         "express",
       ]
     }
-  ]
   ],
   "postUpdateOptions": ["npmDedupe"]
 }


### PR DESCRIPTION
Ref: https://github.com/renovatebot/renovate/discussions/34239#discussioncomment-12238761