### PR TITLE
ci: replace `OCTOKITBOT_PROJECT_ACTION_TOKEN` with a token from https://github.com/apps/octokit

### DIFF
--- a/.github/templates/add_to_octokit_project.yml
+++ b/.github/templates/add_to_octokit_project.yml
@@ -12,9 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/add-to-project@v1.0.1
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.OCTOKIT_APP_ID }}
+          private-key: ${{ secrets.OCTOKIT_APP_PRIVATE_KEY }}
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/octokit/projects/10
-          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           labeled: "Status: Stale"
           label-operator: NOT


### PR DESCRIPTION
Part of https://github.com/octokit/maintainers/issues/34